### PR TITLE
Add the go http-gateway to the pipeline

### DIFF
--- a/sk8s.yml
+++ b/sk8s.yml
@@ -127,7 +127,7 @@ resources:
 - name: go_http-gateway_docker_image
   type: docker-image
   source:
-    repository: ((docker-sk8s-org))/http-gateway-go
+    repository: ((docker-sk8s-org))/http-gateway
     username: ((docker-sk8s-username))
     password: ((docker-sk8s-password))
 

--- a/sk8s.yml
+++ b/sk8s.yml
@@ -83,6 +83,12 @@ resources:
     uri: https://github.com/pivotal-jamie-klassen/function-sidecar.git
     branch: tracing
 
+- name: git-go-http-gateway
+  type: git
+  source:
+    uri: https://github.com/ericbottard/sk8s-http-gateway.git
+    branch: master
+
 - name: git-sk8s
   type: git
   source:
@@ -115,6 +121,13 @@ resources:
   type: docker-image
   source:
     repository: ((docker-sk8s-org))/function-sidecar-go
+    username: ((docker-sk8s-username))
+    password: ((docker-sk8s-password))
+
+- name: go_http-gateway_docker_image
+  type: docker-image
+  source:
+    repository: ((docker-sk8s-org))/http-gateway-go
     username: ((docker-sk8s-username))
     password: ((docker-sk8s-password))
 
@@ -158,6 +171,24 @@ jobs:
     params:
       build: go-sidecar-docker-context
       tag: go-sidecar-docker-context/sk8s_version
+      tag_as_latest: true
+
+- name: build-go-http-gateway
+  serial_groups: [sk8s]
+  plan:
+  - aggregate:
+    - get: git-pfs-ci
+    - get: git-go-http-gateway
+      trigger: true
+    - get: sk8s-version
+
+  - task: build-go-http-gateway
+    file: git-pfs-ci/tasks/build-go-http-gateway.yml
+
+  - put: go_http_gateway_docker_image
+    params:
+      build: build-go-http-gateway-docker-context
+      tag: build-go-http-gateway-docker-context/sk8s_version
       tag_as_latest: true
 
 - name: build-sk8s-containers

--- a/tasks/build-go-http-gateway.yml
+++ b/tasks/build-go-http-gateway.yml
@@ -1,0 +1,46 @@
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: sk8s/kafka-zookeeper
+
+inputs:
+- name: git-go-http-gateway
+- name: git-pfs-ci
+- name: sk8s-version
+
+outputs:
+- name: go-http-gateway-docker-context
+
+run:
+  path: /bin/bash
+  args:
+  - -o
+  - pipefail
+  - -exc
+  - |
+
+    start_kafka
+
+    build_root=$(pwd)
+
+    SK8S_VERSION=$(head "$build_root/sk8s-version/version")
+
+    export GOPATH=$(go env GOPATH)
+
+    mkdir -p "$GOPATH/src/github.com/sk8sio"
+    cp -pr git-go-http-gateway/ "$GOPATH/src/github.com/sk8sio/http-gateway"
+
+    pushd "$GOPATH/src/github.com/sk8sio/http-gateway/"
+
+      make build-for-docker
+
+      KAFKA_BROKER=localhost:9092 go test -v ./...
+
+      pkill -9 java
+
+      cp -r . "$build_root/go-http-gateway-docker-context/"
+
+      cp "$build_root/sk8s-version/version" "$build_root/go-http-gateway-docker-context/sk8s_version"
+
+    popd


### PR DESCRIPTION
The task itself has been tested with 
```
fly -t ci execute -c tasks/build-go-http-gateway.yml -i git-go-http-gateway=$GOPATH/src/github.com/sk8sio/http-gateway -i sk8s-version=/tmp/version -i git-pfs-ci=.
```
the pipeline integration though I haven't tested locally.

The makefile is split up to the point where it actually invokes `docker build` to share as much build steps as possible between "local" build and CI build.

The task is basically a copy/paste of function-sidecar with small corrections as discussed with @freynca (handling of hidden files in particular)